### PR TITLE
Remove buffer.c stuff from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "int",
   "version": "0.0.1",
-  "repo": "visionmedia/buffer.c",
-  "description": "Higher level C-string utilities",
-  "keywords": ["buf", "buffer", "int", "integer", "util", "utils"],
+  "repo": "visionmedia/int.c",
+  "description": "Binary integer representation utilities",
+  "keywords": ["int", "integer", "util", "utils"],
   "license": "MIT",
   "src": ["int.c", "int.h"]
 }


### PR DESCRIPTION
Noticed there was some boilerplate left from buffer.c in the package.json file.
